### PR TITLE
Fix typo in GPT-4 turbo model constant

### DIFF
--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -61,7 +61,9 @@ export const availableModels: IStringKeyMap = {
   'gpt-3.5-turbo-1106': 'gpt-3.5-turbo-1106',
   gpt4: 'gpt-4',
   'gpt-4-turbo': 'gpt-4-turbo',
-  'gpt-4-turo-preview': 'gpt-4-turo-preview',
+  // Note the correct spelling "turbo" below. The previous version had a typo
+  // ("turo"), which resulted in an invalid model option.
+  'gpt-4-turbo-preview': 'gpt-4-turbo-preview',
   'gpt4-0613': 'gpt-4-0613'
 }
 


### PR DESCRIPTION
## Summary
- fix typo in constant for OpenAI model list

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68413d9633048325a21a7c592810e6f9